### PR TITLE
Retirada do * ao lado do campo na tela de cadastro

### DIFF
--- a/src/Form/DadosPessoaisType.php
+++ b/src/Form/DadosPessoaisType.php
@@ -17,19 +17,19 @@ class DadosPessoaisType extends AbstractType
     {
         $builder
             ->add('nome', TextType::class, [
-                'label' => 'Nome *',
+                'label' => 'Nome',
                 'constraints' => [
                     new NotBlank(['message' => 'Este campo é obrigatório']),
                 ],
             ])
             ->add('sobrenome', TextType::class, [
-                'label' => 'Sobrenome *',
+                'label' => 'Sobrenome',
                 'constraints' => [
                     new NotBlank(['message' => 'Este campo é obrigatório']),
                 ],
             ])
             ->add('sexo', ChoiceType::class, [
-                'label' => 'Sexo *',
+                'label' => 'Sexo',
                 'choices' => [
                     'Sexo' => '',
                     'Feminino' => 'Feminino',
@@ -42,7 +42,7 @@ class DadosPessoaisType extends AbstractType
             ])
             ->add('dataNascimento', DateType::class, [
                 'widget' => 'single_text',
-                'label' => 'Data Nascimento *',
+                'label' => 'Data Nascimento',
                 'required' => true,
                 'constraints' => [
                     new NotBlank(['message' => 'Este campo é obrigatório']),


### PR DESCRIPTION
Retirada do asterisco (*) ao lado dos labels dos campos do form de cadastro. Visto que em primeira instância da página não existe nenhum indicador do que significaria esta marcação. 